### PR TITLE
Better stream typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,6 +334,7 @@ dist/cjs
 .rdf-test-suite-cache
 
 test/**/*.d.ts
+test/**/*.js.map
 test/backends/*.js
 test/browser/index.js
 test/browser/index.bundle.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/chai": "^5.2.2",
         "@types/mocha": "^10.0.10",
         "@types/n3": "^1.26.0",
+        "@types/node": "^24.1.0",
         "@types/node-static": "^0.7.11",
         "browser-level": "^3.0.0",
         "chai": "^5.2.0",
@@ -419,9 +420,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
     },
     "node_modules/@types/node-static": {
       "version": "0.7.11",
@@ -3390,6 +3395,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
@@ -4153,9 +4164,12 @@
       }
     },
     "@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "requires": {
+        "undici-types": "~7.8.0"
+      }
     },
     "@types/node-static": {
       "version": "0.7.11",
@@ -6237,6 +6251,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true
+    },
+    "undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
     },
     "update-browserslist-db": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quadstore",
-  "version": "15.3.0",
+  "version": "15.4.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "quadstore",
-      "version": "15.3.0",
+      "version": "15.4.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadstore",
-  "version": "15.3.0",
+  "version": "15.4.0-beta.0",
   "description": "Quadstore is a LevelDB-backed RDF graph database / triplestore for JavaScript runtimes (browsers, Node.js, Deno, Bun, ...) that implements the RDF/JS interfaces and supports SPARQL queries and querying across named graphs.",
   "keywords": [
     "node",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/chai": "^5.2.2",
     "@types/mocha": "^10.0.10",
     "@types/n3": "^1.26.0",
+    "@types/node": "^24.1.0",
     "@types/node-static": "^0.7.11",
     "browser-level": "^3.0.0",
     "chai": "^5.2.0",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -153,6 +153,7 @@ export type TermWriter<T extends Term, E extends 'T' | 'F'> = E extends 'T'
 export interface StreamLike<T = any> extends EventEmitter {
   read(): T | null; 
   destroy?: () => void;
+  readable?: boolean;
   on(event: 'readable', listener: () => void): this;
   on(event: 'end', listener: () => void): this;
   on(event: 'error', listener: (error: Error) => void): this;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,10 +1,10 @@
 
-import type { Readable } from 'stream';
 import type { AbstractChainedBatch, AbstractLevel } from 'abstract-level'
 import type { AsyncIterator } from 'asynciterator';
 import type { Literal, DataFactory, Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph, Quad, Term } from '@rdfjs/types';
 import type { Scope } from '../scope/index.js';
 import type { AbstractIteratorOptions } from 'abstract-level';
+import type { EventEmitter } from 'events';
 
 export interface BatchOpts {
   /**
@@ -26,8 +26,6 @@ export interface PatchOpts extends BatchOpts {
 }
 
 export type TermName = 'subject' | 'predicate' | 'object' | 'graph';
-
-export type TSReadable<T> = Readable | AsyncIterator<T>;
 
 export enum ResultType {
   VOID = 'void',
@@ -151,3 +149,12 @@ export type TermWriter<T extends Term, E extends 'T' | 'F'> = E extends 'T'
   ? { write(node: T, serialized: SerializedTerm, prefixes: Prefixes, rangeMode: boolean, encodedValue: string): void }
   : { write(node: T, serialized: SerializedTerm, prefixes: Prefixes): void }
   ;
+
+export interface StreamLike<T = any> extends EventEmitter {
+  read(): T | null; 
+  destroy?: () => void;
+  on(event: 'readable', listener: () => void): this;
+  on(event: 'end', listener: () => void): this;
+  on(event: 'error', listener: (error: Error) => void): this;
+  on(event: 'data', listener: (item: T) => void): this;
+}

--- a/src/utils/stuff.ts
+++ b/src/utils/stuff.ts
@@ -1,7 +1,7 @@
 
 import type { EventEmitter } from 'events';
 import type { AbstractLevel } from 'abstract-level';
-import type { TSReadable, TermName } from '../types/index.js';
+import type { TermName, StreamLike } from '../types/index.js';
 
 export const isObject = (o: any): boolean => {
   return typeof(o) === 'object' && o !== null;
@@ -20,16 +20,16 @@ export const ensureAbstractLevel = (o: any, key: string) => {
   }
 };
 
-export const streamToArray = <T>(readStream: TSReadable<T>): Promise<T[]> => {
+export const streamToArray = <T>(source: StreamLike<T>): Promise<T[]> => {
   return new Promise((resolve, reject) => {
     const chunks: T[] = [];
     const onData = (chunk: T) => {
       chunks.push(chunk);
     };
     const cleanup = () => {
-      readStream.removeListener('data', onData);
-      readStream.removeListener('error', onError);
-      readStream.destroy();
+      source.removeListener('data', onData);
+      source.removeListener('error', onError);
+      source.destroy?.();
     };
     const onEnd = () => {
       cleanup();
@@ -39,9 +39,9 @@ export const streamToArray = <T>(readStream: TSReadable<T>): Promise<T[]> => {
       cleanup();
       reject(err);
     };
-    readStream.on('error', onError);
-    readStream.on('end', onEnd);
-    readStream.on('data', onData);
+    source.on('error', onError);
+    source.on('end', onEnd);
+    source.on('data', onData);
   });
 }
 

--- a/test/browser/index.ts
+++ b/test/browser/index.ts
@@ -5,6 +5,6 @@ import { runOtherTests } from '../others/others.js';
 import { runTypingsTests } from '../others/typings.js';
 
 runOtherTests();
-runTypingsTests();
+runTypingsTests(false);
 runMemoryLevelTests();
 runBrowserLevelTests();

--- a/test/browser/index.ts
+++ b/test/browser/index.ts
@@ -2,7 +2,9 @@
 import { runMemoryLevelTests } from '../backends/memorylevel.js';
 import { runBrowserLevelTests } from '../backends/browserlevel.js';
 import { runOtherTests } from '../others/others.js';
+import { runTypingsTests } from '../others/typings.js';
 
 runOtherTests();
+runTypingsTests();
 runMemoryLevelTests();
 runBrowserLevelTests();

--- a/test/browser/webpack.config.cjs
+++ b/test/browser/webpack.config.cjs
@@ -20,6 +20,10 @@ module.exports = {
     usedExports: true,
     concatenateModules: false
   },
-  resolve: {},
+  resolve: {
+    fallback: {
+      stream: false,
+    },
+  },
   plugins: []
 };

--- a/test/node.ts
+++ b/test/node.ts
@@ -1,27 +1,10 @@
 
-import type { Readable } from 'stream';
-import type { StreamLike } from '../dist/types/index.js';
-
 import { runMemoryLevelTests } from './backends/memorylevel.js';
 import { runClassicLevelTests } from './backends/classiclevel.js';
 import { runOtherTests } from './others/others.js';
 import { runTypingsTests } from './others/typings.js';
 
 runOtherTests();
-runTypingsTests();
+runTypingsTests(true);
 runMemoryLevelTests();
 runClassicLevelTests();
-
-describe('Typings (Node.js)', () => {
-    
-  describe('StreamLike', () => {
-
-    it('should be extended by Node\'s native Readable interface', () => {
-      const t: StreamLike<any> = ({} as Readable);
-    });
-      
-  });
-    
-});
-
-

--- a/test/node.ts
+++ b/test/node.ts
@@ -1,9 +1,27 @@
 
+import type { Readable } from 'stream';
+import type { StreamLike } from '../dist/types/index.js';
+
 import { runMemoryLevelTests } from './backends/memorylevel.js';
 import { runClassicLevelTests } from './backends/classiclevel.js';
 import { runOtherTests } from './others/others.js';
+import { runTypingsTests } from './others/typings.js';
 
 runOtherTests();
+runTypingsTests();
 runMemoryLevelTests();
 runClassicLevelTests();
+
+describe('Typings (Node.js)', () => {
+    
+  describe('StreamLike', () => {
+
+    it('should be extended by Node\'s native Readable interface', () => {
+      const t: StreamLike<any> = ({} as Readable);
+    });
+      
+  });
+    
+});
+
 

--- a/test/others/typings.ts
+++ b/test/others/typings.ts
@@ -7,8 +7,7 @@ import { Quadstore } from '../../dist/quadstore.js';
 import { MemoryLevel } from 'memory-level';
 import { DataFactory } from 'rdf-data-factory';
 
-
-export const runTypingsTests = () => {
+export const runTypingsTests = (isNode: boolean) => {
   
   describe('Typings', () => { 
     
@@ -29,6 +28,12 @@ export const runTypingsTests = () => {
       
       it('should be extended by the AsyncIterator interface', () => {
         const t: StreamLike<'foo'> = ({} as AsyncIterator<'foo'>);
+      });
+      
+      isNode && it('should be extended by Node\'s native Readable interface', async () => {
+        const { Readable } = await import('stream');
+        const ta: StreamLike<any> = new Readable();
+        const tq: StreamLike<Quad> = new Readable();
       });
       
     });
@@ -69,6 +74,32 @@ export const runTypingsTests = () => {
       
       it('should return an iterable object', async () => { 
         const t: AsyncIterable<Quad> = (await store.getStream({})).iterator;
+      });
+      
+    });
+    
+    describe('Quadstore.prototype.putStream()', () => { 
+      
+      isNode && it('should accept an instance of Node\'s native Readable class', async () => {
+        const { Readable } = await import('stream');
+        await store.putStream(new Readable({
+          read() {
+            this.push(null);
+          }
+        }));
+      });
+      
+    });
+    
+    describe('Quadstore.prototype.delStream()', () => { 
+      
+      isNode && it('should accept an instance of Node\'s native Readable class', async () => {
+        const { Readable } = await import('stream');
+        await store.delStream(new Readable({
+          read() {
+            this.push(null);
+          }
+        }));
       });
       
     });

--- a/test/others/typings.ts
+++ b/test/others/typings.ts
@@ -33,6 +33,14 @@ export const runTypingsTests = () => {
       
     });
     
+    describe('AsyncIterator', () => {
+
+      it('should extend the RDF/JS Stream interface when using the RDF/JS Quad interface as the type parameter', () => {
+        const t: Stream = ({} as AsyncIterator<Quad>);
+      });
+      
+    });
+    
     describe('Quadstore.prototype.match()', () => { 
       
       it('should return an AsyncIterator instance', () => { 

--- a/test/others/typings.ts
+++ b/test/others/typings.ts
@@ -1,0 +1,70 @@
+
+import type { Stream, Quad } from '@rdfjs/types';
+import type { StreamLike } from '../../dist/types/index.js';
+import type { AsyncIterator } from 'asynciterator';
+
+import { Quadstore } from '../../dist/quadstore.js';
+import { MemoryLevel } from 'memory-level';
+import { DataFactory } from 'rdf-data-factory';
+
+
+export const runTypingsTests = () => {
+  
+  describe('Typings', () => { 
+    
+    const store = new Quadstore({
+      backend: new MemoryLevel(),
+      dataFactory: new DataFactory(),
+    });
+    
+    describe('StreamLike', () => {
+
+      it('should extend the RDF/JS Stream interface when using the RDF/JS Quad interface as the type parameter', () => {
+        const t: Stream = ({} as StreamLike<Quad>);
+      });
+    
+      it('should not extend the RDF/JS Stream interface when using anything else but the RDF/JS Quad interface as the type parameter', () => {
+        const t: StreamLike<'foo'> extends Stream ? true : false = false;
+      });
+      
+      it('should be extended by the AsyncIterator interface', () => {
+        const t: StreamLike<'foo'> = ({} as AsyncIterator<'foo'>);
+      });
+      
+    });
+    
+    describe('Quadstore.prototype.match()', () => { 
+      
+      it('should return an AsyncIterator instance', () => { 
+        const t: AsyncIterator<Quad> = store.match();
+      });
+      
+      it('should return a StreamLike object', () => { 
+        const t: StreamLike<Quad> = store.match();
+      });
+      
+      it('should return an iterable object', () => { 
+        const t: AsyncIterable<Quad> = store.match();
+      });
+      
+    });
+    
+    describe('Quadstore.prototype.getStream()', () => { 
+      
+      it('should return an AsyncIterator instance', async () => { 
+        const t: AsyncIterator<Quad> = (await store.getStream({})).iterator;
+      });
+      
+      it('should return a StreamLike object', async () => { 
+        const t: StreamLike<Quad> = (await store.getStream({})).iterator;
+      });
+      
+      it('should return an iterable object', async () => { 
+        const t: AsyncIterable<Quad> = (await store.getStream({})).iterator;
+      });
+      
+    });
+    
+  });
+  
+};

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -47,7 +47,7 @@
     "declaration": false,                                /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./",                                      /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */

--- a/test/utils/stuff.js
+++ b/test/utils/stuff.js
@@ -28,3 +28,4 @@ export const equalsUint8Array = (a, b) => {
     }
     return true;
 };
+//# sourceMappingURL=stuff.js.map


### PR DESCRIPTION
This PR  introduces the `StreamLike` interface, which represents the common API surface that is shared by all the stream-like constructs that Quadstore must support:

- `AsyncIterator` 
- RDF/JS's `Stream`
- Node's `Readable`

This new interface is accompanied by a suite of unit tests focusing on ensuring its compatibility with the above. 

With this new interface, this PR changes the following: 

- All stream-like arguments are now defined using the new `StreamLike` interface, improving compatibility between the RDF/JS methods and the rest of Quadstore's API.
- The return value of the `.match()` method from the RDF/JS `Store` interface is now typed as an `AsyncIterator`, coherently with its actual type at run-time. 

Closes #178 